### PR TITLE
Remove logout and admin dashboard buttons from profile

### DIFF
--- a/WinUIApp.WebUI/Views/Profile/UserPage.cshtml
+++ b/WinUIApp.WebUI/Views/Profile/UserPage.cshtml
@@ -25,13 +25,6 @@
                 <div class="text-center mb-3">
                     <p id="StatusTextBlock">Status: Online</p>
                 </div>
-                <div class="d-grid gap-2">
-                    @if (@Model.CurrentUser.AssignedRole == RoleType.Admin)
-                    {
-                        <a asp-controller="Admin" asp-action="AdminDashboard" class="btn btn-primary">Admin Dashboard</a>
-                    }
-                    <a asp-controller="Profile" asp-action="LogOut" class="btn btn-outline-dark">Logout</a>
-                </div>
             </div>
         </div>
 

--- a/WinUIApp.WebUI/Views/Shared/_Layout.cshtml
+++ b/WinUIApp.WebUI/Views/Shared/_Layout.cshtml
@@ -1,4 +1,9 @@
-﻿<!DOCTYPE html>
+﻿@using DataAccess.Constants
+@using DataAccess.Service
+@using DataAccess.Service.Interfaces
+@using WinUiApp.Data.Data
+@inject IUserService UserService
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
@@ -44,7 +49,7 @@
                     </li>
                         <li class="nav-item">
                             <a class="nav-link text-white" asp-area="" asp-controller="Profile" asp-action="UserPage">
-                                <i class="bi bi-plus-circle me-1"></i> Go to Profile
+                                <i class="bi bi-person me-1"></i> Go To Profile
                             </a>
                         </li>
                     <li class="nav-item">
@@ -53,6 +58,55 @@
                         </a>
                     </li>
                 </ul>
+                @{
+                    User? currentUser = null;
+                    bool isAdmin = false;
+                    bool isUserLoggedIn = false;
+                    
+                    // Don't show buttons on auth pages
+                    string currentController = ViewContext.RouteData.Values["controller"]?.ToString() ?? "";
+                    bool isAuthPage = currentController.Equals("Auth", StringComparison.OrdinalIgnoreCase);
+                    
+                    if (!isAuthPage)
+                    {
+                        try
+                        {
+                            Guid userId = AuthenticationService.GetCurrentUserId();
+                            if (userId != Guid.Empty)
+                            {
+                                currentUser = await UserService.GetUserById(userId);
+                                if (currentUser != null)
+                                {
+                                    isAdmin = currentUser.AssignedRole == RoleType.Admin;
+                                    isUserLoggedIn = true;
+                                }
+                            }
+                        }
+                        catch
+                        {
+                            // User not logged in or error occurred
+                            isUserLoggedIn = false;
+                        }
+                    }
+                }
+                @if (isUserLoggedIn && currentUser != null && !isAuthPage)
+                {
+                    <ul class="navbar-nav">
+                        @if (isAdmin)
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link text-white" asp-area="" asp-controller="Admin" asp-action="AdminDashboard">
+                                    <i class="bi bi-gear me-1"></i> Admin Dashboard
+                                </a>
+                            </li>
+                        }
+                        <li class="nav-item">
+                            <a class="nav-link text-white" asp-area="" asp-controller="Profile" asp-action="LogOut">
+                                <i class="bi bi-box-arrow-right me-1"></i> Logout
+                            </a>
+                        </li>
+                    </ul>
+                } 
             </div>
         </div>
     </nav>


### PR DESCRIPTION
- **Moved logout button** from profile page to main navigation bar for better accessibility
- **Moved admin dashboard button** from profile page to navigation bar with conditional visibility
- **Added role-based logic** to show admin dashboard button only when current user has Admin role
